### PR TITLE
Add CI build config for Github Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,34 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  bigdata-tests:
+    name: "Build and Test"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - "2.7"
+          - "3.7"
+          - "3.9"
+          - "3.10"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '${{ matrix.python_version }}'
+
+      - name: Build and test
+        run: python setup.py test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-          - "2.7"
           - "3.7"
+          - "3.8"
           - "3.9"
           - "3.10"
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ docs/_build/
 # PyBuilder
 target/
 /.eggs/
+
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.6"
-  - "3.7"
-script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # encoding: utf-8
 
 import sys
@@ -10,7 +10,7 @@ if sys.version_info <= (2, 6):
 
 
 setup(
-    name="airspeed",
+    name="airspeed-ext",
     version="0.5.19",
     description=(
         "Airspeed is a powerful and easy-to-use templating engine"


### PR DESCRIPTION
* Add CI build config for Github Actions
* Remove build config for Travis CI
* Rename package to `airspeed-ext`, which we can maintain as our fork on pypi
* Removed support for Python 2.7 in the build matrix, as we're no longer using it in LocalStack (EOL reached), and there are some issues in `setuptools` with 2.7:
```
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 398, in parse_section
    self[name] = value
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 183, in __setitem__
    value = parser(value)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 513, in _parse_version
    version = self._parse_attr(value, self.package_dir)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 349, in _parse_attr
    value = getattr(module, attr_name)
AttributeError: 'module' object has no attribute '__version__'
```

/cc @calvernaz 