### PR TITLE
Improve handling of multi-line dict expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 
 This is a fork of the original [`airspeed`](https://github.com/purcell/airspeed) library, with some extensions used in [LocalStack](https://github.com/localstack/localstack).
 
+⚠️ Note: This fork of `airspeed` focuses on providing maximum parity with AWS' implementation of Velocity templates (used in, e.g., API Gateway or AppSync). In some cases, the behavior may diverge from the VTL spec, or from the Velocity [reference implementation](https://velocity.apache.org/download.cgi).
+
+## Change Log:
+
+* v0.6.1: improve handling of multi-line dict expressions
+* v0.6.0: add initial setup for snapshot testing against AWS and Java VTL; enhance AWS parity
+
+---
+Original README below ...
 ---
 
 ## What is Airspeed?

--- a/airspeed/operators.py
+++ b/airspeed/operators.py
@@ -533,10 +533,10 @@ class ArrayLiteral(_Element):
 
 
 class DictionaryLiteral(_Element):
-    START = re.compile(r"{[ \t]*(.*)$", re.S)
-    END = re.compile(r"[ \t]*}(.*)$", re.S)
-    KEYVALSEP = re.compile(r"[ \t]*:[ \t]*(.*)$", re.S)
-    PAIRSEP = re.compile(r"[ \t]*,[ \t]*(.*)$", re.S)
+    START = re.compile(r"{\s*(.*)$", re.S + re.M)
+    END = re.compile(r"\s*}(.*)$", re.S + re.M)
+    KEYVALSEP = re.compile(r"\s*:\s*(.*)$", re.S + re.M)
+    PAIRSEP = re.compile(r"\s*,\s*(.*)$", re.S + re.M)
 
     def parse(self):
         self.identity_match(self.START)

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import find_packages, setup
 
 setup(
     name="airspeed-ext",
-    version="0.6.0",
+    version="0.6.1",
     description=(
-        "Airspeed is a powerful and easy-to-use templating engine"
-        " for Python that aims for a high level of compatibility "
-        "with the popular Velocity library for Java."
+        "Airspeed is a powerful and easy-to-use templating engine "
+        "for Python that aims for a high level of compatibility "
+        "with Velocity templates in AWS cloud services."
     ),
     author="Steve Purcell, Chris Tarttelin, LocalStack Team",
     author_email="steve@pythonconsulting.com, chris@pythonconsulting.com, info@localstack.cloud",

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -797,6 +797,20 @@ class TestTemplating:
         )
         test_render(template, {"test_dict": {"k1": "v1"}})
 
+    def test_multiline_dict_in_set_statement(self, test_render):
+        template = r"""
+        #set( $myObject = {
+          "userId": "user1",
+          "domain": "domain1"
+        } )
+        {
+          "operation": "PutItem",
+          "key": "$myObject.userId",
+          "domain": "$myObject.domain"
+        }
+        """
+        test_render(template, {"test_dict": {"k1": "v1"}})
+
 
 class TestInternals:
     """

--- a/tests/test_templating.snapshot.json
+++ b/tests/test_templating.snapshot.json
@@ -1005,5 +1005,12 @@
       "render-result-2-cli": "hide me",
       "render-result-2": "hide me"
     }
+  },
+  "tests/test_templating.py::TestTemplating::test_multiline_dict_in_set_statement": {
+    "recorded-date": "25-08-2023, 19:50:40",
+    "recorded-content": {
+      "render-result-1-cli": "\n        {\n          \"operation\": \"PutItem\",\n          \"key\": \"user1\",\n          \"domain\": \"domain1\"\n        }\n        ",
+      "render-result-1": "\n                {\n          \"operation\": \"PutItem\",\n          \"key\": \"user1\",\n          \"domain\": \"domain1\"\n        }\n        "
+    }
   }
 }


### PR DESCRIPTION
Improve handling of multi-line dict expressions. Starting point for this PR was a user issue related to incorrect parsing of multi-line dicts in AppSync VTL templates.

The problem is that the regex patterns were not using the multiline flag (`re.M`) to search for whitespaces (newlines) in dict expressions, which is now fixed. The PR also adds a simple AWS validated snapshot test.