### PR TITLE
Fix putting nulls in maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,9 @@ usage:             ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
 install:           ## Install dependencies in local virtualenv folder
-	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
-		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR)) && \
-		($(VENV_RUN) && $(PIP_CMD) install --upgrade pip) && \
-		($(VENV_RUN); $(PIP_CMD) install .[dev])
+	(test -e $(VENV_DIR) || python -m venv $(VENV_OPTS) $(VENV_DIR)) && \
+	($(VENV_RUN) && $(PIP_CMD) install --upgrade pip) && \
+	($(VENV_RUN); $(PIP_CMD) install .[dev])
 
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a fork of the original [`airspeed`](https://github.com/purcell/airspeed)
 ⚠️ Note: This fork of `airspeed` focuses on providing maximum parity with AWS' implementation of Velocity templates (used in, e.g., API Gateway or AppSync). In some cases, the behavior may diverge from the VTL spec, or from the Velocity [reference implementation](https://velocity.apache.org/download.cgi).
 
 ## Change Log:
+* v0.6.5: handle `$map.put('key', null)` correctly
 * v0.6.4: add support for string.indexOf, string.substring and array.isEmpty
 * v0.6.3: array notation for dicts using string literals and merge upstream patches
 * v0.6.2: add support to contains and toString functions

--- a/airspeed/operators.py
+++ b/airspeed/operators.py
@@ -410,6 +410,17 @@ class FallthroughHashText(_Element):
         stream.write(self.text)
 
 
+class NullLiteral(_Element):
+    NULL = re.compile(r"(?:null)(.*)", re.S)
+
+    def parse(self):
+        self.identity_match(self.NULL)
+        self.value = None
+
+    def calculate(self, namespace, loader):
+        return self.value
+
+
 class IntegerLiteral(_Element):
     INTEGER = re.compile(r"(-?\d+)(.*)", re.S)
 
@@ -576,6 +587,7 @@ class Value(_Element):
     def parse(self):
         self.expression = self.next_element(
             (
+                NullLiteral,
                 FormalReference,
                 FloatingPointLiteral,
                 IntegerLiteral,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="airspeed-ext",
-    version="0.6.4",
+    version="0.6.5",
     description=(
         "Airspeed is a powerful and easy-to-use templating engine "
         "for Python that aims for a high level of compatibility "

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "flake8",
         "flake8-black",
         "flake8-isort",
-        "pytest==6.2.4",
+        "pytest",
         "pytest-httpserver",
     ]},
     test_suite="tests",

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -808,6 +808,19 @@ class TestTemplating:
         )
         test_render(template, {"test_dict": {"k": "initial value"}})
 
+    def test_put_null_in_map(self, test_render):
+        template = r"""
+            #set( $myMap = {} )
+            #set($ignore = $myMap.put('k', null))
+            #if("$myMap.k" == "")
+                "does-not-have-value"
+            #else
+                "has-value"
+            #end
+        """
+        test_render(template, ignore_whitespaces=True)
+
+
     def test_dict_putall_items(self, test_render):
         template = (
             "#set( $ignore = $test_dict.putAll({'k1': 'v3', 'k2': 'v2'}))"

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -820,7 +820,6 @@ class TestTemplating:
         """
         test_render(template, ignore_whitespaces=True)
 
-
     def test_dict_putall_items(self, test_render):
         template = (
             "#set( $ignore = $test_dict.putAll({'k1': 'v3', 'k2': 'v2'}))"

--- a/tests/test_templating.snapshot.json
+++ b/tests/test_templating.snapshot.json
@@ -1061,5 +1061,12 @@
       "render-result-1-cli": " eth",
       "render-result-1": " eth"
     }
+  },
+  "tests/test_templating.py::TestTemplating::test_put_null_in_map": {
+    "recorded-date": "08-12-2023, 17:07:36",
+    "recorded-content": {
+      "render-result-1-cli": "\n                \"has-value\"\n        ",
+      "render-result-1": "\"does-not-have-value\""
+    }
   }
 }


### PR DESCRIPTION
# Motivation

There is a template parsing error for null handling in situations like:

```
$myMap.put('key', null)
```

# Changes

- Handle null values in map.put
- Bump meta information files
