### PR TITLE
Add support for string matches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
           # Note: currently required to import snapshot utils from localstack
           # TODO remove once imports are better organized in localstack
-          . .venv/bin/activate; pip install localstack-core[test]
+          . venv/bin/activate; pip install localstack-core[runtime]
 
       - name: Run tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-          - "3.10"
+          - "3.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
           # Note: currently required to import snapshot utils from localstack
           # TODO remove once imports are better organized in localstack
-          . venv/bin/activate; pip install localstack-core[runtime]
+          . .venv/bin/activate; pip install localstack-core[runtime]
 
       - name: Run tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
           # Note: currently required to import snapshot utils from localstack
           # TODO remove once imports are better organized in localstack
-          . .venv/bin/activate; pip install localstack-core[runtime]
+          . .venv/bin/activate; pip install localstack-core[test]
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a fork of the original [`airspeed`](https://github.com/purcell/airspeed)
 ⚠️ Note: This fork of `airspeed` focuses on providing maximum parity with AWS' implementation of Velocity templates (used in, e.g., API Gateway or AppSync). In some cases, the behavior may diverge from the VTL spec, or from the Velocity [reference implementation](https://velocity.apache.org/download.cgi).
 
 ## Change Log:
+* v0.6.6: add support for `$string.matches( $pattern )`; fix bug where some escaped character would prevent string matching
 * v0.6.5: handle `$map.put('key', null)` correctly
 * v0.6.4: add support for string.indexOf, string.substring and array.isEmpty
 * v0.6.3: array notation for dicts using string literals and merge upstream patches

--- a/airspeed/operators.py
+++ b/airspeed/operators.py
@@ -40,6 +40,7 @@ __additional_methods__ = {
         "contains": lambda self, value: value in self,
         "indexOf": lambda self, ch: self.index(ch),
         "substring": lambda self, start, end=None: self[start:end],
+        "matches": lambda self, pattern: bool(re.fullmatch(pattern, self)),
     },
     list: {
         "size": lambda self: len(self),
@@ -455,7 +456,7 @@ class BooleanLiteral(_Element):
 
 
 class StringLiteral(_Element):
-    STRING = re.compile(r"'((?:\\['nrbt\\\\\\$]|[^'\\])*)'(.*)", re.S)
+    STRING = re.compile(r"'([^']*)'(.*)", re.S)
     ESCAPED_CHAR = re.compile(r"\\([nrbt'\\])")
 
     def parse(self):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "flake8-isort",
         "pytest",
         "pytest-httpserver",
+        "localstack-snapshot"
     ]},
     test_suite="tests",
     tests_require=[],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "flake8-isort",
         "pytest",
         "pytest-httpserver",
-        "localstack-snapshot"
+        "localstack-snapshot",
     ]},
     test_suite="tests",
     tests_require=[],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="airspeed-ext",
-    version="0.6.5",
+    version="0.6.6",
     description=(
         "Airspeed is a powerful and easy-to-use templating engine "
         "for Python that aims for a high level of compatibility "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,12 @@ import pytest
 from localstack.testing.aws.util import (
     base_aws_client_factory,
     base_aws_session,
-    primary_testing_aws_client,
+    base_testing_aws_client,
 )
 
 pytest_plugins = [
     "localstack.testing.pytest.fixtures",
-    "localstack.testing.pytest.snapshot",
+    "localstack_snapshot.pytest.snapshot",
 ]
 
 
@@ -23,4 +23,9 @@ def aws_client_factory(aws_session):
 
 @pytest.fixture(scope="session")
 def aws_client(aws_client_factory):
-    return primary_testing_aws_client(aws_client_factory)
+    return base_testing_aws_client(aws_client_factory)
+
+
+@pytest.fixture(scope="function")
+def snapshot(_snapshot_session):
+    return _snapshot_session

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -845,6 +845,40 @@ class TestTemplating:
         template = "#set( $myObject = {'k1': 'v1', 'k2': 'v2'} )$myObject.toString()"
         test_render(template)
 
+    def test_string_matches_true(self, test_render):
+        template = "#set( $myString = '123456789' )$myString.matches( '[0-9]*' )"
+        test_render(template)
+
+    def test_string_matches_false(self, test_render):
+        template = "#set( $myString = 'd123' )$myString.matches( '[0-9]*' )"
+        test_render(template)
+
+    def test_string_matches_full_date(self, test_render):
+        template = (
+            "#set( $myString = '2020-01-20T08:00:00.000Z' )"
+            "$myString.matches('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$')"  # noqa
+        )
+        test_render(template)
+
+        template = (
+            '#set( $myString = "2020-01-20T08:00:00.000Z" )'
+            '$myString.matches("^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$")'  # noqa
+        )
+        test_render(template)
+
+    def test_string_with_escaped_char(self, test_render):
+        template = "#set( $myString = '\{\n\t\r\%\5' )$myString"  # noqa
+        test_render(template)
+
+        template = '#set( $myString = "\{\n\t\r\%\5" )$myString'  # noqa
+        test_render(template)
+
+        template = "'\{\n\t\r\%\5'"  # noqa
+        test_render(template)
+
+        template = '"\{\n\t\r\%\5"'  # noqa
+        test_render(template)
+
 
 class TestInternals:
     """

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -6,8 +6,8 @@ import textwrap
 import pytest
 import requests
 import six
-from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID
 from localstack.testing.pytest import fixtures
 from localstack.utils.archives import unzip
 from localstack.utils.files import save_file

--- a/tests/test_templating.snapshot.json
+++ b/tests/test_templating.snapshot.json
@@ -1068,5 +1068,41 @@
       "render-result-1-cli": "\n                \"has-value\"\n        ",
       "render-result-1": "\"does-not-have-value\""
     }
+  },
+  "tests/test_templating.py::TestTemplating::test_string_matches_true": {
+    "recorded-date": "24-10-2024, 19:59:43",
+    "recorded-content": {
+      "render-result-1-cli": "true",
+      "render-result-1": "true"
+    }
+  },
+  "tests/test_templating.py::TestTemplating::test_string_matches_false": {
+    "recorded-date": "24-10-2024, 19:59:21",
+    "recorded-content": {
+      "render-result-1-cli": "false",
+      "render-result-1": "false"
+    }
+  },
+  "tests/test_templating.py::TestTemplating::test_string_with_escaped_char": {
+    "recorded-date": "24-10-2024, 22:14:20",
+    "recorded-content": {
+      "render-result-1-cli": "\\{\n\t\r\\%\u0005",
+      "render-result-1": "\\{\n\t\r\\%\u0005",
+      "render-result-2-cli": "\\{\n\t\r\\%\u0005",
+      "render-result-2": "\\{\n\t\r\\%\u0005",
+      "render-result-3-cli": "'\\{\n\t\r\\%\u0005'",
+      "render-result-3": "'\\{\n\t\r\\%\u0005'",
+      "render-result-4-cli": "\"\\{\n\t\r\\%\u0005\"",
+      "render-result-4": "\"\\{\n\t\r\\%\u0005\""
+    }
+  },
+  "tests/test_templating.py::TestTemplating::test_string_matches_full_date": {
+    "recorded-date": "24-10-2024, 21:58:12",
+    "recorded-content": {
+      "render-result-1-cli": "true",
+      "render-result-1": "true",
+      "render-result-2-cli": "true",
+      "render-result-2": "true"
+    }
   }
 }


### PR DESCRIPTION
# Motivation

This pr adds support string utility `matches`. The functionality itself was fairly straightforward but some changes to `StringLiteral` were required to fully support regular expressions. Notably we were only allowing certain characters to be escaped in string literals, while aws accepts **_anything_**. No tests seemed to depend on the escaped character restriction, but it should be safer to run a full suite of localstack tests to ensure this does not create any unforeseen regressions.

Since localstack has gone through a big code restructure since last time this code was change, I have had to update `conftest` and the `main.yml` configuration to be inline with latest development