### PR TITLE
Include localstack-core[runtime] in dev install target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,6 @@ jobs:
           sudo apt-get install -y libsasl2-dev
           make install
 
-          # Note: currently required to import snapshot utils from localstack
-          # TODO remove once imports are better organized in localstack
-          . .venv/bin/activate; pip install localstack-core[runtime]
-
       - name: Run tests
         run: |
           make lint

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install:           ## Install dependencies in local virtualenv folder
 
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive
+	$(VENV_RUN); $(PIP_CMD) install twine
 	$(VENV_RUN); ./setup.py sdist && twine upload $(BUILD_DIR)/*.tar.gz
 
 test:              ## Run automated tests

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "flake8",
         "flake8-black",
         "flake8-isort",
+        "localstack-core[runtime]",
         "pytest",
         "pytest-httpserver",
         "localstack-snapshot",


### PR DESCRIPTION
# Motivation

Currently when setting up this project from the start, some imports are missing, namely

* `localstack`
* `rolo`
* `jinja2`
* ...

# Changes

* Add `localstack-core[runtime]` as a `dev` dependency so getting started is just `make install && make test`
* Remove extra installation of same package from CI file since it's not needed any more
* Before running `twine upload` on publish, install `twine` since this is not included anywhere

Now the getting started steps are the same for CI and locally, which is :thumbsup:

