### PR TITLE
Fix/support for floating point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ var/
 .installed.cfg
 *.egg
 
+# Python environment
+.venv
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a fork of the original [`airspeed`](https://github.com/purcell/airspeed)
 ⚠️ Note: This fork of `airspeed` focuses on providing maximum parity with AWS' implementation of Velocity templates (used in, e.g., API Gateway or AppSync). In some cases, the behavior may diverge from the VTL spec, or from the Velocity [reference implementation](https://velocity.apache.org/download.cgi).
 
 ## Change Log:
+* v0.6.7: fix support for floating point starting with a decimal.
 * v0.6.6: add support for `$string.matches( $pattern )`; fix bug where some escaped character would prevent string matching
 * v0.6.5: handle `$map.put('key', null)` correctly
 * v0.6.4: add support for string.indexOf, string.substring and array.isEmpty

--- a/airspeed/operators.py
+++ b/airspeed/operators.py
@@ -434,7 +434,7 @@ class IntegerLiteral(_Element):
 
 
 class FloatingPointLiteral(_Element):
-    FLOAT = re.compile(r"(-?\d+\.\d+)(.*)", re.S)
+    FLOAT = re.compile(r"(-?\d*\.\d+)(.*)", re.S)
 
     def parse(self):
         (self.value,) = self.identity_match(self.FLOAT)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="airspeed-ext",
-    version="0.6.6",
+    version="0.6.7",
     description=(
         "Airspeed is a powerful and easy-to-use templating engine "
         "for Python that aims for a high level of compatibility "

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -879,6 +879,10 @@ class TestTemplating:
         template = '"\{\n\t\r\%\5"'  # noqa
         test_render(template)
 
+    def test_floating_point_starting_with_decimal(self, test_render):
+        template = """#set($x = .5*.1)$x"""
+        test_render(template)
+
 
 class TestInternals:
     """

--- a/tests/test_templating.snapshot.json
+++ b/tests/test_templating.snapshot.json
@@ -1104,5 +1104,12 @@
       "render-result-2-cli": "true",
       "render-result-2": "true"
     }
+  },
+  "tests/test_templating.py::TestTemplating::test_floating_point_starting_with_decimal": {
+    "recorded-date": "10-11-2024, 04:53:47",
+    "recorded-content": {
+      "render-result-1-cli": "0.05",
+      "render-result-1": "0.05"
+    }
   }
 }


### PR DESCRIPTION
# Motivation

While implementing `$util.math` for appsync, I realised that while aws was recognising `.5` as a floating point, airspeed did not.

This pr makes the leading digits optional when evaluating a floating point element.